### PR TITLE
fix: switch to service account integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ data/
 
 # Never commit environment variables
 .env
+credentials.json

--- a/src/example.js
+++ b/src/example.js
@@ -1,16 +1,29 @@
 const fs = require('fs');
 const path = require('path');
 const {google} = require('googleapis');
-require('dotenv').config();
+// require('dotenv').config();
 
+const SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly'];
 const ALL_QUARTERS_ID = '16vmuNiN-8mij8EoEIwvQ_wde9DgF_0IWXfT_95SHfcc';
 // const ALL_PLEAD_ID = '18nv5m59ppoZLcjKXYziI-PLNx-dkr8i5Avn1ZnjaGiY';
 
-const sheets = google.sheets({version: 'v4', auth: `${process.env.API_KEY}`});
-sheets.spreadsheets.values.get({
-  spreadsheetId: ALL_QUARTERS_ID,
-  range: 'Fall 2016!A:X',
-}).then((response) => formatResponse(response));
+// Load client secrets from a service account
+fs.readFile(path.resolve(__dirname, '../credentials.json'), (err, content) => {
+  authorize(JSON.parse(content), readSheets);
+});
+
+function authorize(credentials, callback) {
+  const jwt = new google.auth.JWT(credentials.client_email, null, credentials.private_key, SCOPES);
+  callback(jwt);
+}
+
+function readSheets(auth) {
+  const sheets = google.sheets({version: 'v4', auth});
+  sheets.spreadsheets.values.get({
+    spreadsheetId: ALL_QUARTERS_ID,
+    range: 'Fall 2016!A:X',
+  }).then((response) => formatResponse(response));
+}
 
 function formatResponse(response){
   const values = response.data.values;


### PR DESCRIPTION
* api key integration exposes our google sheets to the public
* using a service account lets us interact with the google sheets privately

### Steps

1. Create a service account
    * go to your google API dashboard
    * create credentials > service account
    * select current access > owner
    * create key

2. Save the service account credentials

    * download as `.json` format and save to the root of `watchdog` as `credentials.json`

3. Give your service account access to the file

    * take your service account email and share the google sheets to the service account email